### PR TITLE
`org_abbreviation` should be `org_abbreviate`

### DIFF
--- a/OIPA/api/publisher/views.py
+++ b/OIPA/api/publisher/views.py
@@ -30,7 +30,7 @@ class PublisherList(DynamicListView):
     ## Request parameters
 
     - `publisher_iati_id` (*optional*): Publisher id to search for.
-    - `org_abbreviation` (*optional*): Publisher abbreviation to search for.
+    - `org_abbreviate` (*optional*): Publisher abbreviation to search for.
     - `name` (*optional*): Filter publishers name to search for.
 
     ## Result details


### PR DESCRIPTION
Fixes #426 (by updating the docs).