### PR TITLE
Repoint github link to new location

### DIFF
--- a/OIPA/templates/404.html
+++ b/OIPA/templates/404.html
@@ -42,7 +42,7 @@
             <div class="row">
                 <div class="columns small-12 text-center">
                     <div id="logo">
-                        <a href="https://github.com/openaid-IATI/OIPA" target="_blank"></a><img src="{% static "foundation/img/oipa.svg" %}" > on Github
+                        <a href="https://github.com/zimmerman-zimmerman/OIPA" target="_blank"></a><img src="{% static "foundation/img/oipa.svg" %}" > on Github
                     </div>
                     <ul class="tabs">
                         <li class="tab-title active"><a href="/home">Home</a></li>

--- a/OIPA/templates/500.html
+++ b/OIPA/templates/500.html
@@ -42,7 +42,7 @@
             <div class="row">
                 <div class="columns small-12 text-center">
                     <div id="logo">
-                        <a href="https://github.com/openaid-IATI/OIPA" target="_blank"></a><img src="{% static "foundation/img/oipa.svg" %}" > on Github
+                        <a href="https://github.com/zimmerman-zimmerman/OIPA" target="_blank"></a><img src="{% static "foundation/img/oipa.svg" %}" > on Github
                     </div>
                     <ul class="tabs">
                         <li class="tab-title active"><a href="/home">Home</a></li>

--- a/OIPA/templates/home/about.html
+++ b/OIPA/templates/home/about.html
@@ -9,7 +9,7 @@
 	    	<div class="row">
 	    		<div class="columns small-12 text-center">
 	    			<div id="logo" class="visible">
-	    				<a href="https://github.com/openaid-IATI/OIPA" target="_blank"></a><img src="{% static "foundation/img/oipa.svg" %}" > on Github
+	    				<a href="https://github.com/zimmerman-zimmerman/OIPA" target="_blank"></a><img src="{% static "foundation/img/oipa.svg" %}" > on Github
     				</div>
 			    	<ul class="tabs">
 			    		<li class="tab-title"><a href="/home">Home</a></li>

--- a/OIPA/templates/home/home.html
+++ b/OIPA/templates/home/home.html
@@ -45,7 +45,7 @@
 	                <h1>Openaid IATI Parser and API</h1>
 	                <p>OIPA is an IATI data-engine providing a rich and usable API for managing IATI compliant data.</p>
 	                <p class="buttons">
-	                	<a href="https://github.com/openaid-IATI/OIPA" target="_blank" class="button radius roze">OIPA on Github</a>
+	                	<a href="https://github.com/zimmerman-zimmerman/OIPA" target="_blank" class="button radius roze">OIPA on Github</a>
 	                </p>
 	            </div>
 	        </div>
@@ -56,7 +56,7 @@
 	    	<div class="row">
 	    		<div class="columns small-12 text-center">
 	    			<div id="logo">
-	    				<a href="https://github.com/openaid-IATI/OIPA" target="_blank"></a><img src="{% static "foundation/img/oipa.svg" %}" > on Github
+	    				<a href="https://github.com/zimmerman-zimmerman/OIPA" target="_blank"></a><img src="{% static "foundation/img/oipa.svg" %}" > on Github
     				</div>
 			    	<ul class="tabs">
 			    		<li class="tab-title active"><a href="/home">Home</a></li>

--- a/OIPA/templates/rest_framework/api.html
+++ b/OIPA/templates/rest_framework/api.html
@@ -15,7 +15,7 @@
 	    	<div class="row">
 	    		<div class="columns small-12 text-center">
 	    			<div id="logo" class="visible">
-	    				<a href="https://github.com/openaid-IATI/OIPA" target="_blank"></a><img src="{% static "foundation/img/oipa.svg" %}" > on Github
+	    				<a href="https://github.com/zimmerman-zimmerman/OIPA" target="_blank"></a><img src="{% static "foundation/img/oipa.svg" %}" > on Github
     				</div>
 			    	<ul class="tabs">
 			    		<li class="tab-title"><a href="/home">Home</a></li>

--- a/OIPA/templates/two_factor/_base.html
+++ b/OIPA/templates/two_factor/_base.html
@@ -11,7 +11,7 @@
             <div class="row">
                 <div class="columns small-12 text-center">
                     <div id="logo" class="visible">
-                        <a href="https://github.com/openaid-IATI/OIPA" target="_blank"></a><img src="{% static "foundation/img/oipa.svg" %}" > on Github
+                        <a href="https://github.com/zimmerman-zimmerman/OIPA" target="_blank"></a><img src="{% static "foundation/img/oipa.svg" %}" > on Github
                     </div>
                     <ul class="tabs">
                         <li class="tab-title"><a href="/home">Home</a></li>


### PR DESCRIPTION
Github already redirects this, but I suppose you might as well skip the redirect.