### PR TITLE
Transaction list endpoint enhancements

### DIFF
--- a/OIPA/api/transaction/serializers.py
+++ b/OIPA/api/transaction/serializers.py
@@ -138,7 +138,7 @@ class TransactionSerializer(DynamicFieldsModelSerializer):
     description = TransactionDescriptionSerializer()
     humanitarian = serializers.BooleanField()
 
-    activity = ActivitySerializer(read_only=True, fields=('id', 'iati_identifier', 'url'))
+    activity = ActivitySerializer(read_only=True, fields=('id', 'iati_identifier', 'url', 'title'))
     activity_id = serializers.CharField(write_only=True)
 
     class Meta:

--- a/OIPA/api/transaction/views.py
+++ b/OIPA/api/transaction/views.py
@@ -78,7 +78,7 @@ class TransactionList(DynamicListView):
     URI is constructed as follows: `/api/transactions/{transaction_id}`
 
     """
-    queryset = Transaction.objects.all()
+    queryset = Transaction.objects.all().order_by('id')
     serializer_class = TransactionSerializer
     filter_class = TransactionFilter
     pagination_class = CustomTransactionPagination

--- a/OIPA/iati/transaction/transaction_manager.py
+++ b/OIPA/iati/transaction/transaction_manager.py
@@ -24,10 +24,37 @@ class TransactionQuerySet(query.QuerySet):
         ))
 
     def prefetch_all(self):
-        return self.prefetch_description() \
+        return self.prefetch_activity() \
+                .prefetch_description() \
                 .prefetch_provider_organisation() \
-                .prefetch_receiver_organisation() 
+                .prefetch_receiver_organisation() \
+                .prefetch_transaction_type() \
+                .prefetch_currency() \
+                .prefetch_disbursement_channel() \
+                .prefetch_flow_type() \
+                .prefetch_finance_type() \
+                .prefetch_aid_type() \
+                .prefetch_tied_status() \
+                .prefetch_sector() \
+                .prefetch_recipient_country() \
+                .prefetch_recipient_region() \
 
+    def prefetch_activity(self):
+        from iati.models import Narrative
+
+        return self.select_related('activity__title').prefetch_related(
+            Prefetch(
+                'activity__title__narratives',
+                queryset=Narrative.objects.all()
+                .select_related('language'))
+        )
+        # return self.select_related('activity')
+
+    def prefetch_currency(self):
+        return self.select_related('currency')
+
+    def prefetch_transaction_type(self):
+        return self.select_related('transaction_type')
 
     def prefetch_description(self):
         from iati.models import Narrative
@@ -67,3 +94,28 @@ class TransactionQuerySet(query.QuerySet):
                 .select_related('receiver_activity')
                 .prefetch_related(narrative_prefetch)),
         )
+
+    def prefetch_disbursement_channel(self):
+        return self.select_related('disbursement_channel')
+
+    def prefetch_flow_type(self):
+        return self.select_related('flow_type')
+
+    def prefetch_finance_type(self):
+        return self.select_related('finance_type')
+
+    def prefetch_aid_type(self):
+        return self.select_related('aid_type')
+    
+    def prefetch_tied_status(self):
+        return self.select_related('tied_status')
+    
+    def prefetch_sector(self):
+        return self.prefetch_related('transaction_sector')
+    
+    def prefetch_recipient_country(self):
+        return self.prefetch_related('transaction_recipient_country')
+    
+    def prefetch_recipient_region(self):
+        return self.prefetch_related('transaction_recipient_region')
+    


### PR DESCRIPTION
This fixes a couple issues on the transactions endpoint: 

- Add activity title to the transactions endpoint when using the transaction.activity field (users will usually want to add the activity title when listing transactions of multiple activities).
- Add a default order to the transactions list endpoint. DRF warned that it could otherwise produce inconsistent results when using pagination.
- Add prefetches for all transaction fields. In the old scenario /api/transactions/?fields=all&page_size=100 produced ~600 queries, now it produces ~15. 

Prefetches on the transaction endpoint are still untested, would prefer to test them in the same way as api/activity/tests/test_prefetches.py .