### PR TITLE
Reset rest framework's cache every week

### DIFF
--- a/OIPA/OIPA/settings.py
+++ b/OIPA/OIPA/settings.py
@@ -345,7 +345,9 @@ LOGGING = {
 }
 
 REST_FRAMEWORK_EXTENSIONS = {
-    'DEFAULT_USE_CACHE': 'api'
+    'DEFAULT_USE_CACHE': 'api',
+    # reset cache every x seconds:
+    'DEFAULT_CACHE_RESPONSE_TIMEOUT': 1 * 60 * 60 * 24 * 7,  # 1 week
 }
 
 try:


### PR DESCRIPTION
OIPA's API endpoint cache should be reset every week (previously it was never reset)