### PR TITLE
NSC-873

### DIFF
--- a/OIPA/api/unesco/filters.py
+++ b/OIPA/api/unesco/filters.py
@@ -1,4 +1,7 @@
-from django_filters import NumberFilter
+from django_filters import (
+    NumberFilter,
+    DateFilter
+)
 from api.generics.filters import (
     CommaSeparatedCharFilter,
     TogetherFilterSet,
@@ -10,7 +13,7 @@ from unesco.models import TransactionBalance
 class TransactionBalanceFilter(TogetherFilterSet):
 
     reporting_organisation_identifier = CommaSeparatedCharFilter(
-        name='activity__publisher__publisher_iati_id',
+        field_name='activity__publisher__publisher_iati_id',
         lookup_expr='in')
 
     recipient_country = CommaSeparatedCharFilter(
@@ -19,39 +22,55 @@ class TransactionBalanceFilter(TogetherFilterSet):
 
     recipient_region = CommaSeparatedCharFilter(
         lookup_expr='in',
-        name='activity__recipient_region__code')
+        field_name='activity__recipient_region__code')
 
     sector = CommaSeparatedCharFilter(
         lookup_expr='in',
-        name='activity__sector__code')
+        field_name='activity__sector__code')
 
     participating_organisation_name = CommaSeparatedCharFilter(
         lookup_expr='in',
-        name='activity__participating_organisations__primary_name')
+        field_name='activity__participating_organisations__primary_name')
 
     sector_startswith_in = StartsWithInCommaSeparatedCharFilter(
         lookup_expr='startswith',
-        name='activity__sector__code')
+        field_name='activity__sector__code')
 
     total_budget_lte = NumberFilter(
         lookup_expr='lte',
-        name='total_budget')
+        field_name='total_budget')
 
     total_budget_gte = NumberFilter(
         lookup_expr='gte',
-        name='total_budget')
+        field_name='total_budget')
 
     total_expenditure_lte = NumberFilter(
         lookup_expr='lte',
-        name='total_expenditure')
+        field_name='total_expenditure')
 
     total_expenditure_gte = NumberFilter(
         lookup_expr='gte',
-        name='total_expenditure')
+        field_name='total_expenditure')
 
     activity_status = CommaSeparatedCharFilter(
         lookup_expr='in',
-        name='activity__activity_status')
+        field_name='activity__activity_status')
+
+    planned_start_date_lte = DateFilter(
+        lookup_expr='lte',
+        field_name='activity__planned_start')
+
+    planned_start_date_gte = DateFilter(
+        lookup_expr='gte',
+        field_name='activity__planned_start')
+
+    planned_end_date_lte = DateFilter(
+        lookup_expr='lte',
+        field_name='activity__planned_end')
+
+    planned_end_date_gte = DateFilter(
+        lookup_expr='gte',
+        field_name='activity__planned_end')
 
     class Meta:
         model = TransactionBalance

--- a/OIPA/api/unesco/filters.py
+++ b/OIPA/api/unesco/filters.py
@@ -2,14 +2,7 @@ from django_filters import NumberFilter
 from api.generics.filters import (
     CommaSeparatedCharFilter,
     TogetherFilterSet,
-    ToManyFilter,
     StartsWithInCommaSeparatedCharFilter,
-)
-from iati.models import (
-    ActivityRecipientCountry,
-    ActivityRecipientRegion,
-    ActivitySector,
-    ActivityParticipatingOrganisation
 )
 from unesco.models import TransactionBalance
 
@@ -20,29 +13,21 @@ class TransactionBalanceFilter(TogetherFilterSet):
         name='activity__publisher__publisher_iati_id',
         lookup_expr='in')
 
-    recipient_country = ToManyFilter(
-        qs=ActivityRecipientCountry,
+    recipient_country = CommaSeparatedCharFilter(
         lookup_expr='in',
-        name='country__code',
-        fk='activity')
+        name='activity__recipient_country__code')
 
-    recipient_region = ToManyFilter(
-        qs=ActivityRecipientRegion,
+    recipient_region = CommaSeparatedCharFilter(
         lookup_expr='in',
-        name='region__code',
-        fk='activity')
+        name='activity__recipient_region__code')
 
-    sector = ToManyFilter(
-        qs=ActivitySector,
+    sector = CommaSeparatedCharFilter(
         lookup_expr='in',
-        name='sector__code',
-        fk='activity')
+        name='activity__sector__code')
 
-    participating_organisation_name = ToManyFilter(
-        qs=ActivityParticipatingOrganisation,
+    participating_organisation_name = CommaSeparatedCharFilter(
         lookup_expr='in',
-        name='primary_name',
-        fk='activity')
+        name='activity__participating_organisations__primary_name')
 
     sector_startswith_in = StartsWithInCommaSeparatedCharFilter(
         lookup_expr='startswith',
@@ -66,7 +51,7 @@ class TransactionBalanceFilter(TogetherFilterSet):
 
     activity_status = CommaSeparatedCharFilter(
         lookup_expr='in',
-        name='activity_status')
+        name='activity__activity_status')
 
     class Meta:
         model = TransactionBalance

--- a/OIPA/api/unesco/views.py
+++ b/OIPA/api/unesco/views.py
@@ -43,4 +43,9 @@ class TransactionBalanceAggregation(AggregationView):
             fields="activity__publisher__publisher_iati_id",
             renamed_fields="reporting_organisation_identifier",
         ),
+        GroupBy(
+            query_param="activity_iati_identifier",
+            fields="activity__iati_identifier",
+            renamed_fields="activity_iati_identifier",
+        ),
     )


### PR DESCRIPTION
1) When activity status is applied, it break - https://dev.oipa.nl/api/unesco/transaction-balance-aggregations/?reporting_organisation_identifier=XM-DAC-41304&page_size=10&ordering=-activity_commitment_value&format=json&group_by=reporting_organisation_identifier&aggregations=total_budget%2Ctotal_expenditure&sector=02&participating_organisation_name=Airtel%20Gabon&activity_status=3
2) When the budget filter is applied, amounts do not change: https://dev.oipa.nl/api/unesco/transaction-balance-aggregations/?reporting_organisation_identifier=XM-DAC-41304&fields=id%2Ciati_identifier%2Caggregations%2Cactivity_dates%2Ctitle%2Cactivity_status%2Ctransaction_balance&page=1&page_size=10&ordering=-activity_commitment_value&format=json&group_by=reporting_organisation_identifier&aggregations=total_budget%2Ctotal_expenditure&total_commitment_lte=6213235
3) When the expenditure filter is applied, amounts do not change: https://dev.oipa.nl/api/unesco/transaction-balance-aggregations/?reporting_organisation_identifier=XM-DAC-41304&fields=id%2Ciati_identifier%2Caggregations%2Cactivity_dates%2Ctitle%2Cactivity_status%2Ctransaction_balance&page=1&page_size=10&ordering=-activity_commitment_value&format=json&group_by=reporting_organisation_identifier&aggregations=total_budget%2Ctotal_expenditure&total_expenditure_lte=7953814
4) When the start and end date filters are applied nothing changes - https://dev.oipa.nl/api/unesco/transaction-balance-aggregations/?reporting_organisation_identifier=XM-DAC-41304&fields=id%2Ciati_identifier%2Caggregations%2Cactivity_dates%2Ctitle%2Cactivity_status%2Ctransaction_balance&page=1&page_size=10&ordering=-activity_commitment_value&format=json&group_by=reporting_organisation_identifier&aggregations=total_budget%2Ctotal_expenditure&planned_start_date_gte=2018-02-01    AND     https://dev.oipa.nl/api/unesco/transaction-balance-aggregations/?reporting_organisation_identifier=XM-DAC-41304&fields=id%2Ciati_identifier%2Caggregations%2Cactivity_dates%2Ctitle%2Cactivity_status%2Ctransaction_balance&page=1&page_size=10&ordering=-activity_commitment_value&format=json&group_by=reporting_organisation_identifier&aggregations=total_budget%2Ctotal_expenditure&planned_end_date_gte=2018-12-01

https://zimmermanzimmerman.atlassian.net/browse/NSC-873