### PR TITLE
NSC-881

### DIFF
--- a/OIPA/api/unesco/filters.py
+++ b/OIPA/api/unesco/filters.py
@@ -36,19 +36,19 @@ class TransactionBalanceFilter(TogetherFilterSet):
         lookup_expr='startswith',
         field_name='activity__sector__code')
 
-    total_budget_lte = NumberFilter(
+    transactionbalance_total_budget_lte = NumberFilter(
         lookup_expr='lte',
         field_name='total_budget')
 
-    total_budget_gte = NumberFilter(
+    transactionbalance_total_budget_gte = NumberFilter(
         lookup_expr='gte',
         field_name='total_budget')
 
-    total_expenditure_lte = NumberFilter(
+    transactionbalance_total_expenditure_lte = NumberFilter(
         lookup_expr='lte',
         field_name='total_expenditure')
 
-    total_expenditure_gte = NumberFilter(
+    transactionbalance_total_expenditure_gte = NumberFilter(
         lookup_expr='gte',
         field_name='total_expenditure')
 


### PR DESCRIPTION
https://zimmermanzimmerman.atlassian.net/browse/NSC-881

For the 'http://localhost:8000/api/unesco/transaction-balance-aggregations/' fIltering by budget and expenditure needs to work with this kind of a parameter: 'transactionbalance_total_budget_gte=1000000' . Currently this parameter is working with the api calls to retrieve the correct project list(though it needs to be implemented).
Example of how the '/unesco/transaction-balance-aggregations/' could/should look:
http://localhost:8000/api/unesco/transaction-balance-aggregations/?reporting_organisation_identifier=XM-DAC-41304&fields=id%2Ciati_identifier%2Caggregations%2Cactivity_dates%2Ctitle%2Cactivity_status%2Ctransaction_balance&page=1&page_size=10&ordering=-activity_commitment_value&format=json&group_by=reporting_organisation_identifier&aggregations=total_budget%2Ctotal_expenditure&transactionbalance_total_budget_gte=1000000
Example of the project list where the parameter is working:
https://dev.oipa.nl/api/activities/?reporting_organisation_identifier=XM-DAC-41304&fields=id%2Ciati_identifier%2Caggregations%2Cactivity_dates%2Ctitle%2Cactivity_status%2Ctransaction_balance&page=1&page_size=10&ordering=-activity_commitment_value&format=json&transactionbalance_total_budget_gte=1000000