### PR TITLE
Bugfix/oipa 780

### DIFF
--- a/OIPA/iati_synchroniser/admin.py
+++ b/OIPA/iati_synchroniser/admin.py
@@ -163,7 +163,6 @@ class DatasetAdmin(admin.ModelAdmin):
     def add_to_parse_queue(self, request):
         xml_id = request.GET.get('xml_id')
         obj = get_object_or_404(Dataset, pk=xml_id)
-        #force_parse_source_by_url(obj.source_url)
         queue = django_rq.get_queue("parser")
         queue.enqueue(force_parse_source_by_url, args=(
             obj.source_url, True), timeout=7200)

--- a/OIPA/iati_synchroniser/admin.py
+++ b/OIPA/iati_synchroniser/admin.py
@@ -163,9 +163,11 @@ class DatasetAdmin(admin.ModelAdmin):
     def add_to_parse_queue(self, request):
         xml_id = request.GET.get('xml_id')
         obj = get_object_or_404(Dataset, pk=xml_id)
+        #force_parse_source_by_url(obj.source_url)
         queue = django_rq.get_queue("parser")
         queue.enqueue(force_parse_source_by_url, args=(
             obj.source_url, True), timeout=7200)
+
         return HttpResponse('Success')
 
     def parse_activity_view(self, request, activity_id):

--- a/OIPA/templates/django_rq/stats.html
+++ b/OIPA/templates/django_rq/stats.html
@@ -793,7 +793,9 @@ $(document).ready(function (){
         var taskName = $('select[name="add-task-select-default"]').val();
         var btn = $('#add-task-button-default');
         var parameters = $('input[name="add-task-default-parameters"]').val();
+        $('input[name="add-task-default-parameters"]').val('');
         var parameters2 = $('input[name="add-task-default-parameters-2"]').val();
+        $('input[name="add-task-default-parameters"]').val('');
         var queue =  "default";
 
         $.ajax({

--- a/OIPA/templates/django_rq/stats.html
+++ b/OIPA/templates/django_rq/stats.html
@@ -795,7 +795,7 @@ $(document).ready(function (){
         var parameters = $('input[name="add-task-default-parameters"]').val();
         $('input[name="add-task-default-parameters"]').val('');
         var parameters2 = $('input[name="add-task-default-parameters-2"]').val();
-        $('input[name="add-task-default-parameters"]').val('');
+        $('input[name="add-task-default-parameters-2"]').val('');
         var queue =  "default";
 
         $.ajax({


### PR DESCRIPTION
FIX....In http://localhost:8000/admin/queue/, when a task which requires no positional arguments is called after a task which requires positional arguments, arguments from a previous task are passed to the next one and we get a typeError: update_region_data() takes 0 positional arguments but 2 were given exception