### PR TITLE
Pip install setuptools before ipython

### DIFF
--- a/bin/setup/install_dependencies.sh
+++ b/bin/setup/install_dependencies.sh
@@ -26,6 +26,7 @@ sudo apt-get install -y binutils libproj-dev gdal-bin libgeos-3.5.0 libgeos-dev
 sudo apt-get install -y redis-server
 
 # pip dependencies
+sudo pip install setuptools
 sudo pip install ipython
 
 # fulltext Python library for extracting text from various file formats (for indexing).


### PR DESCRIPTION
Prevents `ImportError: No module named setuptools` when running `sudo pip install ipython`