### PR TITLE
NSC-1064

### DIFF
--- a/OIPA/api/renderers.py
+++ b/OIPA/api/renderers.py
@@ -129,7 +129,8 @@ class PaginatedCSVRenderer(CSVRenderer):
         actual_kwargs = args[1].get('kwargs', {})
 
         # this is a list view
-        if 'pk' not in actual_kwargs:
+        if 'pk' not in actual_kwargs \
+                and 'iati_identifier' not in actual_kwargs:
             data = data.get(self.results_field, [])
 
         return super(PaginatedCSVRenderer, self).render(data, *args, **kwargs)

--- a/OIPA/api/renderers.py
+++ b/OIPA/api/renderers.py
@@ -111,6 +111,7 @@ class XMLRenderer(BaseRenderer):
             pass
 
 
+# TODO: test this, see: #958
 class PaginatedCSVRenderer(CSVRenderer):
     results_field = 'results'
     header = []
@@ -151,7 +152,7 @@ class OrganisationXMLRenderer(XMLRenderer):
 
 
 # XXX: file name is always 'download' and it should probably be set per-view
-# TODO: test
+# TODO: test this, see: #958
 class XlsRenderer(BaseRenderer):
     media_type = 'application/vnd.ms-excel'
     results_field = 'results'

--- a/OIPA/api/renderers.py
+++ b/OIPA/api/renderers.py
@@ -128,9 +128,18 @@ class PaginatedCSVRenderer(CSVRenderer):
         # need to update this - 2017-04-03
         actual_kwargs = args[1].get('kwargs', {})
 
-        # this is a list view
+        # So basically when exporting a list view we need to only
+        # parse what we get from the 'results' field of the response
+        # otherwise what we see in the file, will not make much sense
+        # so we do a check here to determine if the response is a list
+        # response or a detail response, by checking if there's a
+        # 'pk' or a 'iati_identifier'
+        # one of the exceptions is for the 'activity/{id}/transactions'
+        # because it returns a list so we have a check for it here as well
         if 'pk' not in actual_kwargs \
-                and 'iati_identifier' not in actual_kwargs:
+            and 'iati_identifier' not in actual_kwargs or \
+            'pk' in actual_kwargs and \
+                'transactions' in args[1]['request']._request.path:
             data = data.get(self.results_field, [])
 
         return super(PaginatedCSVRenderer, self).render(data, *args, **kwargs)
@@ -140,9 +149,6 @@ class OrganisationXMLRenderer(XMLRenderer):
     root_tag_name = 'iati-organisations'
     item_tag_name = 'iati-organisation'
 
-
-# All of this was done in the same way that the csv is formed
-# Which was okay for them peeps
 
 # XXX: file name is always 'download' and it should probably be set per-view
 # TODO: test
@@ -187,9 +193,18 @@ class XlsRenderer(BaseRenderer):
 
         actual_kwargs = renderer_context.get('kwargs', {})
 
-        # this is a list view
+        # So basically when exporting a list view we need to only
+        # parse what we get from the 'results' field of the response
+        # otherwise what we see in the file, will not make much sense
+        # so we do a check here to determine if the response is a list
+        # response or a detail response, by checking if there's a
+        # 'pk' or a 'iati_identifier'
+        # one of the exceptions is for the 'activity/{id}/transactions'
+        # because it returns a list so we have a check for it here as well
         if 'pk' not in actual_kwargs \
-                and 'iati_identifier' not in actual_kwargs:
+                and 'iati_identifier' not in actual_kwargs or\
+                'pk' in actual_kwargs and \
+                'transactions' in renderer_context['request']._request.path:
             data = data.get(self.results_field, [])
 
         # Create an in-memory output file for the new workbook.

--- a/OIPA/api/renderers.py
+++ b/OIPA/api/renderers.py
@@ -187,7 +187,8 @@ class XlsRenderer(BaseRenderer):
         actual_kwargs = renderer_context.get('kwargs', {})
 
         # this is a list view
-        if 'pk' not in actual_kwargs:
+        if 'pk' not in actual_kwargs \
+                and 'iati_identifier' not in actual_kwargs:
             data = data.get(self.results_field, [])
 
         # Create an in-memory output file for the new workbook.


### PR DESCRIPTION
https://zimmermanzimmerman.atlassian.net/browse/NSC-1064

File is empty when the activity detail ID is a IATI identifier.
Check this - 
https://dev.oipa.nl/api/activities/XM-DAC-41304-38-1211/?format=csv&export_fields=

{%22id%22:%22ID%22,%22iati_identifier%22:%22IATI%20identifier%22,%22title.narratives.0.text%22:%22Project:%22,%22transaction_balance.total_budget%22:%22Budget%22,%22transaction_balance.total_expenditure%22:%22Expenditures%22,%22transaction_balance.cumulative_budget%22:%22Cumulative%20budget%22,%22transaction_balance.cumulative_expenditure%22:%22Cumulative%20expenditures%22,%22descriptions.0.narratives.0.text%22:%22Description%22,%22activity_dates.0.iso_date%22:%22Start:%20%22,%22activity_dates.1.iso_date%22:%22End:%20%22,%22activity_status.name%22:%22Project%20Status%22}
&export_name=UnescoData