### PR TITLE
DFID fixes

### DIFF
--- a/OIPA/api/activity/serializers.py
+++ b/OIPA/api/activity/serializers.py
@@ -637,6 +637,7 @@ class ActivityAggregationSerializer(DynamicFieldsSerializer):
     incoming_commitment_currency = serializers.CharField()
 
 
+# TODO: test
 class CustomReportingOrganisationURLSerializer(
         serializers.HyperlinkedIdentityField):
     """A custom serializer to allow to use different argument for

--- a/OIPA/api/activity/serializers.py
+++ b/OIPA/api/activity/serializers.py
@@ -661,7 +661,7 @@ class ReportingOrganisationSerializer(DynamicFieldsModelSerializer):
         view_name='organisations:organisation-detail',
     )
     type = CodelistSerializer(source="publisher.organisation.type")
-    secondary_reporter = serializers.BooleanField()
+    secondary_reporter = serializers.BooleanField(required=False)
 
     activity = serializers.CharField(write_only=True)
 

--- a/OIPA/api/activity/serializers.py
+++ b/OIPA/api/activity/serializers.py
@@ -637,7 +637,6 @@ class ActivityAggregationSerializer(DynamicFieldsSerializer):
     incoming_commitment_currency = serializers.CharField()
 
 
-# TODO: test
 class CustomReportingOrganisationURLSerializer(
         serializers.HyperlinkedIdentityField):
     """A custom serializer to allow to use different argument for

--- a/OIPA/api/activity/serializers.py
+++ b/OIPA/api/activity/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
+from rest_framework.reverse import reverse
 
 from api.activity.filters import RelatedActivityFilter
 from api.codelist.serializers import (
@@ -636,10 +637,27 @@ class ActivityAggregationSerializer(DynamicFieldsSerializer):
     incoming_commitment_currency = serializers.CharField()
 
 
+class CustomReportingOrganisationURLSerializer(
+        serializers.HyperlinkedIdentityField):
+    """A custom serializer to allow to use different argument for
+       HyperlinkedIdentityField for ReportingOrganisation serializer
+    """
+
+    def get_url(self, obj, view_name, request, format):
+        url_kwargs = {
+            'pk': obj.publisher.organisation.organisation_identifier
+        }
+        return reverse(
+            view_name, kwargs=url_kwargs, request=request, format=format)
+
+
 class ReportingOrganisationSerializer(DynamicFieldsModelSerializer):
     # TODO: Link to organisation standard (hyperlinked)
     ref = serializers.CharField(
         source="publisher.organisation.organisation_identifier"
+    )
+    url = CustomReportingOrganisationURLSerializer(
+        view_name='organisations:organisation-detail',
     )
     type = CodelistSerializer(source="publisher.organisation.type")
     secondary_reporter = serializers.BooleanField()
@@ -657,6 +675,7 @@ class ReportingOrganisationSerializer(DynamicFieldsModelSerializer):
         fields = (
             'id',
             'ref',
+            'url',
             'type',
             'secondary_reporter',
             'narratives',

--- a/OIPA/api/activity/tests/test_activity_endpoints.py
+++ b/OIPA/api/activity/tests/test_activity_endpoints.py
@@ -1,4 +1,6 @@
 import json
+from collections import OrderedDict
+from datetime import datetime
 
 from django.test import RequestFactory
 from django.urls import reverse
@@ -8,6 +10,7 @@ from rest_framework.test import APIClient, APITestCase
 from iati.factory import iati_factory
 from iati.factory.iati_factory import ActivityFactory
 from iati.permissions.factories import OrganisationUserFactory
+from iati.transaction.factories import TransactionFactory
 from iati_synchroniser.factory.synchroniser_factory import PublisherFactory
 
 
@@ -147,3 +150,89 @@ class TestActivityEndpoints(APITestCase):
         assert url == expect_url, msg.format(expect_url)
         response = self.c.get(url)
         self.assertTrue(status.is_success(response.status_code))
+
+    def test_activity_transactions_by_iati_identifier_endpoint(self):
+
+        transaction = TransactionFactory(activity=self.activity)
+
+        url = reverse(
+            'activities:activity-transactions-by-iati-identifier',
+            args={
+                self.activity.iati_identifier
+            }
+        )
+        response = self.c.get(url)
+        self.assertTrue(status.is_success(response.status_code))
+
+        self.assertEqual(
+            response.data,
+            OrderedDict([
+                ('count', self.activity.transaction_set.count()),
+                ('next', None),
+                ('previous', None),
+                ('results', [OrderedDict([
+                    ('id', transaction.id),
+                    ('activity', OrderedDict([
+                        ('url', 'http://testserver{0}'.format(
+                            reverse(
+                                'activities:activity-detail',
+                                kwargs={'pk': self.activity.pk}
+                            )
+                        )),
+                        ('id', str(self.activity.id)),
+                        ('iati_identifier', self.activity.iati_identifier),
+                        ('title', None)
+                    ])),
+                    ('url', 'http://testserver{0}'.format(
+                        reverse(
+                            'transactions:transaction-detail',
+                            kwargs={'pk': transaction.pk}
+                        )
+                    )),
+                    ('ref', transaction.ref),
+                    ('humanitarian', transaction.humanitarian),
+                    ('transaction_type', OrderedDict([
+                        ('code', transaction.transaction_type.code),
+                        ('name', transaction.transaction_type.name)
+                    ])),
+                    ('transaction_date', datetime.strftime(
+                        transaction.transaction_date, '%Y-%m-%d'
+                    )),
+                    # 2 numbers after comma:
+                    ('value', format(transaction.value, '.2f')),
+                    ('value_date', datetime.strftime(
+                        transaction.value_date, '%Y-%m-%d'
+                    )),
+                    ('currency', OrderedDict([
+                        ('code', transaction.currency.code),
+                        ('name', transaction.currency.name)
+                    ])),
+                    ('description', None),
+                    ('provider_organisation', None),
+                    ('receiver_organisation', None),
+                    ('disbursement_channel', OrderedDict([
+                        ('code', transaction.disbursement_channel.code),
+                        (
+                            'name',
+                            transaction.disbursement_channel.name
+                        )
+                    ]
+                    )),
+                    ('sector', None),
+                    ('recipient_country', None),
+                    ('recipient_region', None),
+                    ('flow_type', OrderedDict([
+                        ('code', transaction.flow_type.code),
+                        ('name', transaction.flow_type.name)
+                    ])),
+                    ('finance_type', OrderedDict([
+                        ('code', transaction.finance_type.code),
+                        ('name', transaction.finance_type.name)
+                    ])),
+                    ('aid_type', None),
+                    ('tied_status', OrderedDict([
+                        ('code', transaction.tied_status.code),
+                        ('name', transaction.tied_status.name)
+                    ]))
+                ])])])
+        )

--- a/OIPA/api/activity/urls.py
+++ b/OIPA/api/activity/urls.py
@@ -24,6 +24,9 @@ urlpatterns = [
     url(r'^(?P<pk>\d+)/transactions/$',
         api.activity.views.ActivityTransactionList.as_view(),
         name='activity-transactions'),
+    url(r'^(?P<iati_identifier>[\w-]+)/transactions$',
+        api.activity.views.ActivityTransactionListByIatiIdentifier.as_view(),
+        name='activity-transactions-by-iati-identifier'),
 
     url(r'^(?P<pk>\d+)/transactions/(?P<id>[^@$&+,/:;=?]+)$',
         api.activity.views.ActivityTransactionDetail.as_view(),

--- a/OIPA/api/activity/urls.py
+++ b/OIPA/api/activity/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     url(r'^(?P<pk>\d+)/transactions/$',
         api.activity.views.ActivityTransactionList.as_view(),
         name='activity-transactions'),
-    url(r'^(?P<iati_identifier>[\w-]+)/transactions$',
+    url(r'^(?P<iati_identifier>[\w-]+)/transactions/$',
         api.activity.views.ActivityTransactionListByIatiIdentifier.as_view(),
         name='activity-transactions-by-iati-identifier'),
 

--- a/OIPA/api/activity/views.py
+++ b/OIPA/api/activity/views.py
@@ -556,7 +556,6 @@ class ActivityTransactionList(DynamicListView):
             return Transaction.objects.none().order_by('id')
 
 
-# TODO: test
 class ActivityTransactionListByIatiIdentifier(DynamicListView):
     """
     Returns a list of IATI Activity Transactions stored in OIPA.
@@ -564,7 +563,7 @@ class ActivityTransactionListByIatiIdentifier(DynamicListView):
     ## URI Format
 
     ```
-    /api/activities/{activity_id}/transactions
+    /api/activities/{iati_identifier}/transactions
     ```
 
     ### URI Parameters

--- a/OIPA/api/activity/views.py
+++ b/OIPA/api/activity/views.py
@@ -556,6 +556,75 @@ class ActivityTransactionList(DynamicListView):
             return Transaction.objects.none().order_by('id')
 
 
+# TODO: test
+class ActivityTransactionListByIatiIdentifier(DynamicListView):
+    """
+    Returns a list of IATI Activity Transactions stored in OIPA.
+
+    ## URI Format
+
+    ```
+    /api/activities/{activity_id}/transactions
+    ```
+
+    ### URI Parameters
+
+    - `iati_identifier`: Desired activity IATI identifier
+
+    ## Request parameters:
+
+    - `recipient_country` (*optional*): Recipient countries list.
+        Comma separated list of strings.
+    - `recipient_region` (*optional*): Recipient regions list.
+        Comma separated list of integers.
+    - `sector` (*optional*): Sectors list. Comma separated list of integers.
+    - `sector_category` (*optional*): Sectors list. Comma separated list of integers.
+    - `reporting_organisations` (*optional*): Organisation ID's list.
+    - `participating_organisations` (*optional*): Organisation IDs list.
+        Comma separated list of strings.
+    - `min_total_budget` (*optional*): Minimal total budget value.
+    - `max_total_budget` (*optional*): Maximal total budget value.
+    - `activity_status` (*optional*):
+
+
+    - `related_activity_id` (*optional*):
+    - `related_activity_type` (*optional*):
+    - `related_activity_recipient_country` (*optional*):
+    - `related_activity_recipient_region` (*optional*):
+    - `related_activity_sector` (*optional*):
+
+    ## Searching is performed on fields:
+
+    - `description`
+    - `provider_organisation_name`
+    - `receiver_organisation_name`
+
+    """  # NOQA: E501
+    serializer_class = TransactionSerializer
+    filter_class = TransactionFilter
+
+    # TODO: Create cached logic for this class
+    """
+    This class has unique URL so not compatible the rest_framework_extensions
+    cached. We should make a Params Key Constructor function
+    then override the default below function and will be like below:
+
+    @cache_response(key_func=YourQueryParamsKeyConstructor())
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
+    """
+
+    def get_queryset(self):
+        # Override default get query to get transaction list by primary key of
+        # the activity
+        iati_identifier = self.kwargs.get('iati_identifier')
+        try:
+            return Activity.objects.get(iati_identifier=iati_identifier).\
+                transaction_set.all().order_by('id')
+        except Activity.DoesNotExist:
+            return Transaction.objects.none().order_by('id')
+
+
 class ActivityTransactionDetail(CacheResponseMixin, DynamicDetailView):
     serializer_class = TransactionSerializer
 

--- a/OIPA/task_queue/tasks.py
+++ b/OIPA/task_queue/tasks.py
@@ -88,6 +88,7 @@ def perform_initial_tasks():
     queue = django_rq.get_queue("default")
     queue.enqueue(update_iati_codelists)
     queue.enqueue(update_country_data)
+    queue.enqueue(update_region_data)
     queue.enqueue(get_new_sources_from_iati_api)
 
 

--- a/README.MD
+++ b/README.MD
@@ -93,6 +93,8 @@ Pytest-django is used to run tests. This will be installed automatically when th
 
 To run tests, from the top level directory of the project, run ```pytest OIPA/```. If you are in the same directory where ```manage.py``` is, only running ```pytest``` will be sufficient. Refer to <a href="https://pytest-django.readthedocs.io/en/latest/#" target="_blank">Pytest-django documentations</a> for details.
 
+Tip: to be able to use debuggers (f. ex. ipdb) with pytest, run it with `-s` option (to turn off capturing test output).
+
 Testing / code quality settings can be found in the `setup.cfg` file. Test coverage settings (for pytest-cov plugin) can be found at `.coveragerc` file.
 
 


### PR DESCRIPTION
This PR basically includes a few things:

* `ReportingOrganisationSerializer` now returns current Activity Reporting Organisation URL (I suppose this was working previously)
* Activity transactions are now accessible with URL using Activity `iati_identifier`
* Region data is also updated when "run initial tasks" wrapper task is ran