### PR TITLE
Feature/same db for tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,6 @@ RUN apt-get -y install \
     unrar \
     unrtf \
     unzip \
-    libsqlite3-dev  \
-    libsqlite3-mod-spatialite \
     sqlite3 \
     libpq-dev \
     python-psycopg2 \
@@ -50,8 +48,7 @@ RUN apt-get -y install \
     uwsgi-plugin-python \
     python3-pip \
     vim \
-    locales \
-    libsqlite3-mod-spatialite
+    locales
 
 RUN mkdir /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get -y install \
     unrar \
     unrtf \
     unzip \
-    sqlite3 \
     libpq-dev \
     python-psycopg2 \
     uwsgi \

--- a/OIPA/OIPA/settings.py
+++ b/OIPA/OIPA/settings.py
@@ -31,9 +31,6 @@ DATABASES = {
     },
 }
 
-# For testing with spatialite
-SPATIALITE_LIBRARY_PATH = 'mod_spatialite'
-
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/OIPA/OIPA/test_settings.py
+++ b/OIPA/OIPA/test_settings.py
@@ -1,14 +1,4 @@
-import os
-
 from OIPA.production_settings import *  # noqa: F401, F403
-
-# XXX: Note, that for OS X you'll probably need something different, something
-# like '/usr/local/lib/mod_spatialite.dylib' or smth.
-# See:https://docs.djangoproject.com/en/2.0/ref/contrib/gis/install/spatialite/
-SPATIALITE_LIBRARY_PATH = os.getenv(
-    'SPATIALITE_LIBRARY_PATH',
-    'mod_spatialite',
-)
 
 FTS_ENABLED = False
 CKAN_URL = "https://iati-staging.ckan.io"

--- a/OIPA/OIPA/test_settings.py
+++ b/OIPA/OIPA/test_settings.py
@@ -10,13 +10,6 @@ SPATIALITE_LIBRARY_PATH = os.getenv(
     'mod_spatialite',
 )
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.contrib.gis.db.backends.spatialite',
-        'NAME': ':memory:',
-    },
-}
-
 FTS_ENABLED = False
 CKAN_URL = "https://iati-staging.ckan.io"
 

--- a/OIPA/api/activity/tests/test_save_serializers.py
+++ b/OIPA/api/activity/tests/test_save_serializers.py
@@ -3058,7 +3058,10 @@ class ResultIndicatorSaveTestCase(TestCase):
 
         instance2 = iati_models.ResultIndicatorTitle.objects.get(
             result_indicator_id=res.json()['id'])
-        narratives2 = instance2.narratives.all()
+
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(narratives2[0].content,
                          data['title']['narratives'][0]['text'])
         self.assertEqual(narratives2[1].content,
@@ -3141,7 +3144,10 @@ class ResultIndicatorSaveTestCase(TestCase):
 
         instance2 = iati_models.ResultIndicatorTitle.objects.get(
             result_indicator_id=res.json()['id'])
-        narratives2 = instance2.narratives.all()
+
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(narratives2[0].content,
                          data['title']['narratives'][0]['text'])
         self.assertEqual(narratives2[1].content,
@@ -3382,7 +3388,9 @@ class OtherIdentifierSaveTestCase(TestCase):
         self.assertEqual(instance.type.code, str(data['type']['code']))
         self.assertEqual(instance.owner_ref, data['owner_org']['ref'])
 
-        narratives = instance.narratives.all()
+        # order by creation time ('id')
+        narratives = instance.narratives.all().order_by('id')
+
         self.assertEqual(narratives[0].content,
                          data['owner_org']['narratives'][0]['text'])
         self.assertEqual(narratives[1].content,
@@ -3391,7 +3399,7 @@ class OtherIdentifierSaveTestCase(TestCase):
     def test_update_other_identifier(self):
         other_identifier = OtherIdentifierFactory.create()
         other_identifier_type = codelist_factory.OtherIdentifierTypeFactory\
-            .create(code="A100")
+            .create(code="A10")
 
         data = {
             "activity": other_identifier.activity.id,
@@ -3432,7 +3440,9 @@ class OtherIdentifierSaveTestCase(TestCase):
         self.assertEqual(instance.type.code, str(data['type']['code']))
         self.assertEqual(instance.owner_ref, data['owner_org']['ref'])
 
-        narratives = instance.narratives.all()
+        # order by creation time ('id')
+        narratives = instance.narratives.all().order_by('id')
+
         self.assertEqual(narratives[0].content,
                          data['owner_org']['narratives'][0]['text'])
         self.assertEqual(narratives[1].content,
@@ -3593,7 +3603,9 @@ class BudgetItemSaveTestCase(TestCase):
                          data['country_budget_item'])
         self.assertEqual(instance.code.code, data['budget_identifier']['code'])
 
-        narratives = instance.description.narratives.all()
+        # order by creation time ('id')
+        narratives = instance.description.narratives.all().order_by('id')
+
         self.assertEqual(narratives[0].content,
                          data['description']['narratives'][0]['text'])
         self.assertEqual(narratives[1].content,
@@ -3637,7 +3649,9 @@ class BudgetItemSaveTestCase(TestCase):
                          data['country_budget_item'])
         self.assertEqual(instance.code.code, data['budget_identifier']['code'])
 
-        narratives = instance.description.narratives.all()
+        # order by creation time ('id')
+        narratives = instance.description.narratives.all().order_by('id')
+
         self.assertEqual(narratives[0].content,
                          data['description']['narratives'][0]['text'])
         self.assertEqual(narratives[1].content,
@@ -3856,7 +3870,9 @@ class ConditionSaveTestCase(TestCase):
         self.assertEqual(instance.conditions.id, data['conditions'])
         self.assertEqual(instance.type.code, data['type']['code'])
 
-        narratives = instance.narratives.all()
+        # order by creation time ('id')
+        narratives = instance.narratives.all().order_by('id')
+
         self.assertEqual(narratives[0].content, data['narratives'][0]['text'])
         self.assertEqual(narratives[1].content, data['narratives'][1]['text'])
 
@@ -3897,7 +3913,9 @@ class ConditionSaveTestCase(TestCase):
         self.assertEqual(instance.conditions.id, data['conditions'])
         self.assertEqual(instance.type.code, data['type']['code'])
 
-        narratives = instance.narratives.all()
+        # order by creation time ('id')
+        narratives = instance.narratives.all().order_by('id')
+
         self.assertEqual(narratives[0].content, data['narratives'][0]['text'])
         self.assertEqual(narratives[1].content, data['narratives'][1]['text'])
 
@@ -4535,7 +4553,10 @@ class DocumentLinkSaveTestCase(TestCase):
 
         instance2 = iati_models.DocumentLinkTitle.objects.get(
             document_link_id=res.json()['id'])
-        narratives2 = instance2.narratives.all()
+
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(narratives2[0].content,
                          data['title']['narratives'][0]['text'])
         self.assertEqual(narratives2[1].content,
@@ -4590,7 +4611,10 @@ class DocumentLinkSaveTestCase(TestCase):
 
         instance2 = iati_models.DocumentLinkTitle.objects.get(
             document_link_id=res.json()['id'])
-        narratives2 = instance2.narratives.all()
+
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(narratives2[0].content,
                          data['title']['narratives'][0]['text'])
         self.assertEqual(narratives2[1].content,

--- a/OIPA/api/activity/tests/test_save_serializers.py
+++ b/OIPA/api/activity/tests/test_save_serializers.py
@@ -209,7 +209,9 @@ class ActivitySaveTestCase(TestCase):
                          data['secondary_reporter'])
 
         title = instance.title
-        title_narratives = title.narratives.all()
+
+        # order by creation time ('id')
+        title_narratives = title.narratives.all().order_by('id')
         self.assertEqual(
             title_narratives[0].content,
             data['title']['narratives'][0]['text']
@@ -318,7 +320,10 @@ class ActivitySaveTestCase(TestCase):
                          data['secondary_reporter'])
 
         title = instance.title
-        title_narratives = title.narratives.all()
+
+        # order by creation time ('id')
+        title_narratives = title.narratives.all().order_by('id')
+
         self.assertEqual(
             title_narratives[0].content,
             data['title']['narratives'][0]['text']
@@ -392,7 +397,9 @@ class DescriptionSaveTestCase(TestCase):
         self.assertEqual(instance.activity.id, data['activity'])
         self.assertEqual(instance.type.code, data['type']['code'])
 
-        narratives = instance.narratives.all()
+        # order by creation time ('id')
+        narratives = instance.narratives.all().order_by('id')
+
         self.assertEqual(narratives[0].content, data['narratives'][0]['text'])
         self.assertEqual(narratives[1].content, data['narratives'][1]['text'])
 
@@ -431,7 +438,9 @@ class DescriptionSaveTestCase(TestCase):
         self.assertEqual(instance.activity.id, data['activity'])
         self.assertEqual(instance.type.code, str(data['type']['code']))
 
-        narratives = instance.narratives.all()
+        # order by creation time ('id')
+        narratives = instance.narratives.all().order_by('id')
+
         self.assertEqual(narratives[0].content, data['narratives'][0]['text'])
         self.assertEqual(narratives[1].content, data['narratives'][1]['text'])
 
@@ -513,7 +522,9 @@ class ParticipatingOrganisationSaveTestCase(TestCase):
         self.assertEqual(instance.type.code, str(data['type']['code']))
         self.assertEqual(instance.role.code, str(data['role']['code']))
 
-        narratives = instance.narratives.all()
+        # order by creation time ('id')
+        narratives = instance.narratives.all().order_by('id')
+
         self.assertEqual(narratives[0].content, data['narratives'][0]['text'])
         self.assertEqual(narratives[1].content, data['narratives'][1]['text'])
 
@@ -570,7 +581,9 @@ class ParticipatingOrganisationSaveTestCase(TestCase):
         self.assertEqual(instance.type.code, str(data['type']['code']))
         self.assertEqual(instance.role.code, str(data['role']['code']))
 
-        narratives = instance.narratives.all()
+        # order by creation time ('id')
+        narratives = instance.narratives.all().order_by('id')
+
         self.assertEqual(narratives[0].content, data['narratives'][0]['text'])
         self.assertEqual(narratives[1].content, data['narratives'][1]['text'])
 
@@ -777,7 +790,10 @@ class ContactInfoSaveTestCase(TestCase):
         self.assertEqual(instance.activity.id, data['activity'])
         self.assertEqual(instance.type.code, data['type']['code'])
 
-        organisation_narratives = instance.organisation.narratives.all()
+        # order by creation time ('id')
+        organisation_narratives = instance.organisation.narratives.all()\
+            .order_by('id')
+
         self.assertEqual(
             organisation_narratives[0].content,
             data['organisation']['narratives'][0]['text'])
@@ -785,7 +801,10 @@ class ContactInfoSaveTestCase(TestCase):
             organisation_narratives[1].content,
             data['organisation']['narratives'][1]['text'])
 
-        department_narratives = instance.department.narratives.all()
+        # order by creation time ('id')
+        department_narratives = instance.department.narratives.all()\
+            .order_by('id')
+
         self.assertEqual(
             department_narratives[0].content,
             data['department']['narratives'][0]['text'])
@@ -793,7 +812,10 @@ class ContactInfoSaveTestCase(TestCase):
             department_narratives[1].content,
             data['department']['narratives'][1]['text'])
 
-        person_name_narratives = instance.person_name.narratives.all()
+        # order by creation time ('id')
+        person_name_narratives = instance.person_name.narratives.all()\
+            .order_by('id')
+
         self.assertEqual(
             person_name_narratives[0].content,
             data['person_name']['narratives'][0]['text'])
@@ -801,7 +823,10 @@ class ContactInfoSaveTestCase(TestCase):
             person_name_narratives[1].content,
             data['person_name']['narratives'][1]['text'])
 
-        job_title_narratives = instance.job_title.narratives.all()
+        # order by creation time ('id')
+        job_title_narratives = instance.job_title.narratives.all()\
+            .order_by('id')
+
         self.assertEqual(
             job_title_narratives[0].content,
             data['job_title']['narratives'][0]['text'])
@@ -809,7 +834,10 @@ class ContactInfoSaveTestCase(TestCase):
             job_title_narratives[1].content,
             data['job_title']['narratives'][1]['text'])
 
-        mailing_address_narratives = instance.mailing_address.narratives.all()
+        # order by creation time ('id')
+        mailing_address_narratives = instance.mailing_address.narratives.all()\
+            .order_by('id')
+
         self.assertEqual(
             mailing_address_narratives[0].content,
             data['mailing_address']['narratives'][0]['text'])
@@ -896,7 +924,10 @@ class ContactInfoSaveTestCase(TestCase):
         self.assertEqual(instance.activity.id, data['activity'])
         self.assertEqual(instance.type.code, data['type']['code'])
 
-        organisation_narratives = instance.organisation.narratives.all()
+        # order by creation time ('id')
+        organisation_narratives = instance.organisation.narratives.all()\
+            .order_by('id')
+
         self.assertEqual(
             organisation_narratives[0].content,
             data['organisation']['narratives'][0]['text'])
@@ -904,7 +935,10 @@ class ContactInfoSaveTestCase(TestCase):
             organisation_narratives[1].content,
             data['organisation']['narratives'][1]['text'])
 
-        department_narratives = instance.department.narratives.all()
+        # order by creation time ('id')
+        department_narratives = instance.department.narratives.all()\
+            .order_by('id')
+
         self.assertEqual(
             department_narratives[0].content,
             data['department']['narratives'][0]['text'])
@@ -912,7 +946,10 @@ class ContactInfoSaveTestCase(TestCase):
             department_narratives[1].content,
             data['department']['narratives'][1]['text'])
 
-        person_name_narratives = instance.person_name.narratives.all()
+        # order by creation time ('id')
+        person_name_narratives = instance.person_name.narratives.all()\
+            .order_by('id')
+
         self.assertEqual(
             person_name_narratives[0].content,
             data['person_name']['narratives'][0]['text'])
@@ -920,7 +957,10 @@ class ContactInfoSaveTestCase(TestCase):
             person_name_narratives[1].content,
             data['person_name']['narratives'][1]['text'])
 
-        job_title_narratives = instance.job_title.narratives.all()
+        # order by creation time ('id')
+        job_title_narratives = instance.job_title.narratives.all()\
+            .order_by('id')
+
         self.assertEqual(
             job_title_narratives[0].content,
             data['job_title']['narratives'][0]['text'])
@@ -928,7 +968,10 @@ class ContactInfoSaveTestCase(TestCase):
             job_title_narratives[1].content,
             data['job_title']['narratives'][1]['text'])
 
-        mailing_address_narratives = instance.mailing_address.narratives.all()
+        # order by creation time ('id')
+        mailing_address_narratives = instance.mailing_address.narratives.all()\
+            .order_by('id')
+
         self.assertEqual(
             mailing_address_narratives[0].content,
             data['mailing_address']['narratives'][0]['text'])
@@ -1383,13 +1426,18 @@ class LocationSaveTestCase(TestCase):
         self.assertEqual(
             str(instance.point_pos[1]), data['point']['pos']['latitude'])
 
-        name_narratives = instance.name.narratives.all()
+        # order by creation time ('id')
+        name_narratives = instance.name.narratives.all().order_by('id')
+
         self.assertEqual(
             name_narratives[0].content, data['name']['narratives'][0]['text'])
         self.assertEqual(
             name_narratives[1].content, data['name']['narratives'][1]['text'])
 
-        description_narratives = instance.description.narratives.all()
+        # order by creation time ('id')
+        description_narratives = instance.description.narratives.all()\
+            .order_by('id')
+
         self.assertEqual(
             description_narratives[0].content,
             data['description']['narratives'][0]['text'])
@@ -1397,8 +1445,10 @@ class LocationSaveTestCase(TestCase):
             description_narratives[1].content,
             data['description']['narratives'][1]['text'])
 
+        # order by creation time ('id')
         activity_description_narratives = instance.activity_description.\
-            narratives.all()
+            narratives.all().order_by('id')
+
         self.assertEqual(
             activity_description_narratives[0].content,
             data['activity_description']['narratives'][0]['text'])
@@ -1519,13 +1569,18 @@ class LocationSaveTestCase(TestCase):
         self.assertEqual(
             str(instance.point_pos[1]), data['point']['pos']['latitude'])
 
-        name_narratives = instance.name.narratives.all()
+        # order by creation time ('id')
+        name_narratives = instance.name.narratives.all().order_by('id')
+
         self.assertEqual(
             name_narratives[0].content, data['name']['narratives'][0]['text'])
         self.assertEqual(
             name_narratives[1].content, data['name']['narratives'][1]['text'])
 
-        description_narratives = instance.description.narratives.all()
+        # order by creation time ('id')
+        description_narratives = instance.description.narratives.all()\
+            .order_by('id')
+
         self.assertEqual(
             description_narratives[0].content,
             data['description']['narratives'][0]['text'])
@@ -1533,8 +1588,10 @@ class LocationSaveTestCase(TestCase):
             description_narratives[1].content,
             data['description']['narratives'][1]['text'])
 
+        # order by creation time ('id')
         activity_description_narratives = instance.activity_description.\
-            narratives.all()
+            narratives.all().order_by('id')
+
         self.assertEqual(
             activity_description_narratives[0].content,
             data['activity_description']['narratives'][0]['text'])
@@ -1733,7 +1790,9 @@ class PolicyMarkerSaveTestCase(TestCase):
         self.assertEqual(instance.significance.code,
                          str(data['significance']['code']))
 
-        narratives = instance.narratives.all()
+        # order by creation time ('id')
+        narratives = instance.narratives.all().order_by('id')
+
         self.assertEqual(narratives[0].content, data['narratives'][0]['text'])
         self.assertEqual(narratives[1].content, data['narratives'][1]['text'])
 
@@ -1792,7 +1851,9 @@ class PolicyMarkerSaveTestCase(TestCase):
         self.assertEqual(instance.significance.code,
                          str(data['significance']['code']))
 
-        narratives = instance.narratives.all()
+        # order by creation time ('id')
+        narratives = instance.narratives.all().order_by('id')
+
         self.assertEqual(narratives[0].content, data['narratives'][0]['text'])
         self.assertEqual(narratives[1].content, data['narratives'][1]['text'])
 
@@ -2055,7 +2116,9 @@ class PlannedDisbursementSaveTestCase(TestCase):
             data['provider_organisation']['type']['code']))
         self.assertEqual(instance2.provider_activity.id, activity.id)
 
-        narratives2 = instance2.narratives.all()
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(
             narratives2[0].content,
             data['provider_organisation']['narratives'][0]['text']
@@ -2078,7 +2141,9 @@ class PlannedDisbursementSaveTestCase(TestCase):
         self.assertEqual(instance3.receiver_activity.id,
                          data['receiver_organisation']['receiver_activity'])
 
-        narratives3 = instance3.narratives.all()
+        # order by creation time ('id')
+        narratives3 = instance3.narratives.all().order_by('id')
+
         self.assertEqual(
             narratives3[0].content,
             data['receiver_organisation']['narratives'][0]['text']
@@ -2185,7 +2250,9 @@ class PlannedDisbursementSaveTestCase(TestCase):
         self.assertEqual(instance2.provider_activity.id,
                          planned_disbursement.activity.id)
 
-        narratives2 = instance2.narratives.all()
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(
             narratives2[0].content,
             data['provider_organisation']['narratives'][0]['text']
@@ -2208,7 +2275,9 @@ class PlannedDisbursementSaveTestCase(TestCase):
         self.assertEqual(instance3.receiver_activity.id,
                          data['receiver_organisation']['receiver_activity'])
 
-        narratives3 = instance3.narratives.all()
+        # order by creation time ('id')
+        narratives3 = instance3.narratives.all().order_by('id')
+
         self.assertEqual(
             narratives3[0].content,
             data['receiver_organisation']['narratives'][0]['text']
@@ -2441,7 +2510,9 @@ class TransactionSaveTestCase(TestCase):
             data['provider_organisation']['type']['code']))
         self.assertEqual(instance2.provider_activity.id, activity.id)
 
-        narratives2 = instance2.narratives.all()
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(
             narratives2[0].content,
             data['provider_organisation']['narratives'][0]['text']
@@ -2465,7 +2536,9 @@ class TransactionSaveTestCase(TestCase):
             instance3.receiver_activity.iati_identifier,
             data['receiver_organisation']['receiver_activity_id'])
 
-        narratives3 = instance3.narratives.all()
+        # order by creation time ('id')
+        narratives3 = instance3.narratives.all().order_by('id')
+
         self.assertEqual(
             narratives3[0].content,
             data['receiver_organisation']['narratives'][0]['text']
@@ -2688,7 +2761,9 @@ class TransactionSaveTestCase(TestCase):
             data['provider_organisation']['type']['code']))
         self.assertEqual(instance2.provider_activity.id, instance.activity.id)
 
-        narratives2 = instance2.narratives.all()
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(
             narratives2[0].content,
             data['provider_organisation']['narratives'][0]['text']
@@ -2707,7 +2782,9 @@ class TransactionSaveTestCase(TestCase):
         self.assertEqual(instance3.receiver_activity.id,
                          data['receiver_organisation']['receiver_activity_id'])
 
-        narratives3 = instance3.narratives.all()
+        # order by creation time ('id')
+        narratives3 = instance3.narratives.all().order_by('id')
+
         self.assertEqual(
             narratives3[0].content,
             data['receiver_organisation']['narratives'][0]['text']
@@ -2798,7 +2875,10 @@ class ResultSaveTestCase(TestCase):
 
         instance2 = iati_models.ResultTitle.objects.get(
             result_id=res.json()['id'])
-        narratives2 = instance2.narratives.all()
+
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(narratives2[0].content,
                          data['title']['narratives'][0]['text'])
         self.assertEqual(narratives2[1].content,
@@ -2806,7 +2886,10 @@ class ResultSaveTestCase(TestCase):
 
         instance2 = iati_models.ResultDescription.objects.get(
             result_id=res.json()['id'])
-        narratives2 = instance2.narratives.all()
+
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(narratives2[0].content,
                          data['description']['narratives'][0]['text'])
         self.assertEqual(narratives2[1].content,
@@ -2861,7 +2944,10 @@ class ResultSaveTestCase(TestCase):
 
         instance2 = iati_models.ResultTitle.objects.get(
             result_id=res.json()['id'])
-        narratives2 = instance2.narratives.all()
+
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(narratives2[0].content,
                          data['title']['narratives'][0]['text'])
         self.assertEqual(narratives2[1].content,
@@ -2869,7 +2955,10 @@ class ResultSaveTestCase(TestCase):
 
         instance2 = iati_models.ResultDescription.objects.get(
             result_id=res.json()['id'])
-        narratives2 = instance2.narratives.all()
+
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(narratives2[0].content,
                          data['description']['narratives'][0]['text'])
         self.assertEqual(narratives2[1].content,
@@ -2977,7 +3066,10 @@ class ResultIndicatorSaveTestCase(TestCase):
 
         instance2 = iati_models.ResultIndicatorDescription.objects.get(
             result_indicator_id=res.json()['id'])
-        narratives2 = instance2.narratives.all()
+
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(narratives2[0].content,
                          data['description']['narratives'][0]['text'])
         self.assertEqual(narratives2[1].content,
@@ -3057,7 +3149,10 @@ class ResultIndicatorSaveTestCase(TestCase):
 
         instance2 = iati_models.ResultIndicatorDescription.objects.get(
             result_indicator_id=res.json()['id'])
-        narratives2 = instance2.narratives.all()
+
+        # order by creation time ('id')
+        narratives2 = instance2.narratives.all().order_by('id')
+
         self.assertEqual(narratives2[0].content,
                          data['description']['narratives'][0]['text'])
         self.assertEqual(narratives2[1].content,

--- a/OIPA/api/activity/tests/test_save_serializers.py
+++ b/OIPA/api/activity/tests/test_save_serializers.py
@@ -4194,7 +4194,7 @@ class CrsAddOtherFlagsSaveTestCase(TestCase):
             "/api/publishers/{}/activities/{}/crs_add/{}/other_flags/{}?format=json".format(  # NOQA: E501
                 self.publisher.id,
                 crs_add_other_flags.crs_add.activity.id,
-                crs_add_other_flags.crs_add.id,
+                crs_add_other_flags.id,
                 crs_add_other_flags.id),
             data,
             format='json'
@@ -4216,7 +4216,7 @@ class CrsAddOtherFlagsSaveTestCase(TestCase):
             "/api/publishers/{}/activities/{}/crs_add/{}/other_flags/{}?format=json".format(  # NOQA: E501
                 self.publisher.id,
                 crs_add_other_flags.crs_add.activity.id,
-                crs_add_other_flags.crs_add.id,
+                crs_add_other_flags.id,
                 crs_add_other_flags.id),
             format='json'
         )

--- a/OIPA/api/region/tests/test_region_endpoints.py
+++ b/OIPA/api/region/tests/test_region_endpoints.py
@@ -3,6 +3,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from geodata.factory import geodata_factory
+from iati_vocabulary.factory import vocabulary_factory
 
 
 class TestRegionEndpoints(APITestCase):
@@ -17,7 +18,12 @@ class TestRegionEndpoints(APITestCase):
         self.assertTrue(status.is_success(response.status_code))
 
     def test_region_detail_endpoint(self):
-        geodata_factory.RegionFactory.create(code='998')
+        rv = vocabulary_factory.RegionVocabularyFactory()
+
+        geodata_factory.RegionFactory.create(
+            code='998',
+            region_vocabulary=rv,
+        )
         url = reverse('regions:region-detail', args={'998'})
 
         msg = 'region detail endpoint should be localed at {0}'

--- a/OIPA/api/transaction/tests/test_transaction_aggregation.py
+++ b/OIPA/api/transaction/tests/test_transaction_aggregation.py
@@ -71,9 +71,10 @@ class TransactionAggregationTestCase(TestCase):
             vocabulary=transaction_sector.vocabulary
         )
 
-        country = iati_factory.CountryFactory.build(code="AD", name="Andorra")
-        second_country = iati_factory.CountryFactory.build(
-            code="KE", name="Kenya")
+        country = iati_factory.CountryFactory(code="AD", name="Andorra")
+        second_country = iati_factory.CountryFactory(
+            code="KE", name="Kenya"
+        )
 
         transaction_factory.TransactionRecipientCountryFactory.create(
             transaction=first_transaction,

--- a/OIPA/geodata/importer/tests/test_country_import.py
+++ b/OIPA/geodata/importer/tests/test_country_import.py
@@ -4,6 +4,7 @@ from mock import MagicMock
 from geodata.factory.geodata_factory import CountryFactory, RegionFactory
 from geodata.importer.country import CountryImport
 from geodata.models import Country
+from iati_vocabulary.factory import vocabulary_factory
 
 
 class CountryImportTestCase(TestCase):
@@ -47,7 +48,9 @@ class CountryImportTestCase(TestCase):
         self.assertEqual(country.center_longlat.x, 1.3)
 
     def test_update_regions(self):
-        region = RegionFactory.create(code='689')
+        rv = vocabulary_factory.RegionVocabularyFactory()
+
+        region = RegionFactory.create(code='689', region_vocabulary=rv)
         data = [{
             "country_name": "Afghanistan",
             "iso2": "AF",

--- a/OIPA/geodata/importer/tests/test_region_import.py
+++ b/OIPA/geodata/importer/tests/test_region_import.py
@@ -4,13 +4,19 @@ from mock import MagicMock
 from geodata.factory.geodata_factory import RegionFactory
 from geodata.importer.region import RegionImport
 from geodata.models import Region
+from iati_vocabulary.factory import vocabulary_factory
 
 
 class RegionAdminTestCase(TestCase):
 
     def setUp(self):
         self.region_import = RegionImport()
-        self.region = RegionFactory.create(code='689')
+
+        self.rv = vocabulary_factory.RegionVocabularyFactory()
+        self.region = RegionFactory.create(
+            code='689',
+            region_vocabulary=self.rv
+        )
 
     def test_import_region_center(self):
         data = {"689": {"latitude": "38.526682", "longitude": "69.697266"}, }

--- a/OIPA/iati/factory/iati_factory.py
+++ b/OIPA/iati/factory/iati_factory.py
@@ -127,6 +127,7 @@ class CountryFactory(NoDatabaseFactory):
     code = 'AD'
     name = 'andorra'
     iso3 = 'and'
+    center_longlat = Point(1, 3)
 
 
 class ActivityDummyFactory(NoDatabaseFactory):

--- a/OIPA/iati/parser/tests/test_2_03_parser.py
+++ b/OIPA/iati/parser/tests/test_2_03_parser.py
@@ -570,7 +570,7 @@ class RecipientCountryTestCase(TestCase):
         # 'percentage' attr is wrong:
 
         # let's create Country object so parser doesn't complain anymore:
-        country = iati_factory.CountryFactory(code='LTU')
+        country = iati_factory.CountryFactory(code='LT')
 
         # Clear cache (from memory):
         self.parser_203.codelist_cache = {}

--- a/OIPA/iati/tests/test_parser_fields.py
+++ b/OIPA/iati/tests/test_parser_fields.py
@@ -2252,11 +2252,16 @@ class BudgetTestCase(ParserSetupTestCase):
         convert.currency_from_to = MagicMock(return_value=xdr_value)
 
         value = E('value', text, **attrs)
+
+        # Register model for parser, because the method that will try to access
+        # it wont fail:
+        self.parser_202.register_model('Budget', iati_factory.BudgetFactory(
+            activity=self.activity
+        ))
+
         self.parser_202.iati_activities__iati_activity__budget__value(value)
+
         budget = self.parser_202.get_model('Budget')
-        budget.activity.save()
-        budget.activity = budget.activity
-        budget.save()
 
         self.assertEqual(budget.value, Decimal('2000.2'))
         self.assertEqual(str(budget.value_date), attrs['value-date'])
@@ -2379,13 +2384,20 @@ class PlannedDisbursementTestCase(ParserSetupTestCase):
         text = "2000.2"
 
         value = E('value', text, **attrs)
+
+        # Register model for parser, because the method that will try to access
+        # it wont fail:
+        self.parser_202.register_model(
+            'PlannedDisbursement',
+            iati_factory.PlannedDisbursementFactory(
+                activity=self.activity
+            )
+        )
+
         self.parser_202\
             .iati_activities__iati_activity__planned_disbursement__value(
                 value)
         planned_disbursement = self.parser_202.get_model('PlannedDisbursement')
-        planned_disbursement.activity.save()
-        planned_disbursement.activity = planned_disbursement.activity
-        planned_disbursement.save()
 
         self.assertEqual(planned_disbursement.value, Decimal('2000.2'))
         self.assertEqual(str(planned_disbursement.value_date),

--- a/OIPA/iati_organisation/tests/test_2_03_organisation_parser.py
+++ b/OIPA/iati_organisation/tests/test_2_03_organisation_parser.py
@@ -11,6 +11,7 @@ from iati.parser.exceptions import (
 )
 from iati.parser.parse_manager import ParseManager
 from iati_codelists.factory import codelist_factory
+from iati_codelists.factory.codelist_factory import VersionFactory
 from iati_synchroniser.factory import synchroniser_factory
 from iati_vocabulary.factory.vocabulary_factory import RegionVocabularyFactory
 
@@ -35,6 +36,8 @@ class OrganisationsOrganisationTestCase(DjangoTestCase):
 
         self.default_currency = codelist_factory.CurrencyFactory()
         self.default_language = codelist_factory.LanguageFactory()
+
+        VersionFactory(code='2.03')
 
     def test_iati_organisations__iati_organisation(self):
 


### PR DESCRIPTION
This feature is about not using different database for testing, because it does not make any sense to do so.

With this change `django.contrib.gis.db.backends.postgis` database will be used for _everything_ in OIPA.