### PR TITLE
DEV-204

### DIFF
--- a/OIPA/api/activity/filters.py
+++ b/OIPA/api/activity/filters.py
@@ -592,16 +592,18 @@ class ActivityFilter(TogetherFilterSet):
 
     def filter_recipient_location(self, queryset, name, value):
         if value == 'countries':
-            return queryset.filter(Q(activityrecipientcountry__isnull=False))
+            return queryset.filter(
+                Q(activityrecipientcountry__isnull=False)
+            ).distinct()
         elif value == 'regions':
             return queryset.filter(
                 Q(activityrecipientregion__isnull=False) &
                 ~Q(activityrecipientregion__region__code='99')
-            )
+            ).distinct()
         elif value == 'global':
             return queryset.filter(
                 Q(activityrecipientregion__region__code='99')
-            )
+            ).distinct()
     recipient_location = CharFilter(method='filter_recipient_location')
 
     class Meta:


### PR DESCRIPTION
https://zimmermanzimmerman.atlassian.net/browse/DEV-204

oipa activities calls with the filter 'recipient_location' returns duplicate activities.

@Martizs This is only for Unesco, please make a ticket for Yoda version.