### PR TITLE
OIPA-1477

### DIFF
--- a/OIPA/iati/parser/IATI_2_02.py
+++ b/OIPA/iati/parser/IATI_2_02.py
@@ -3320,14 +3320,12 @@ class Parse(IatiParser):
         try:
             value = Decimal(value)
         except Exception as e:
-            value = None
-
-        if value is None:
-            raise RequiredFieldError(
-                "result/indicator/period/period/target",
-                "value",
-                "required attribute missing (this error might be incorrect, \
-                        xsd:decimal is used to check instead of xsd:string)")
+            value = 0   # value could be None according to
+            # iati-specification but we should not add None to our database
+            # otherwise it would raise error in endpoint aggregation.
+            # Example API call:
+            # /api/results/aggregations/?group_by=result_indicator_title
+            # &aggregations=actuals&format=json
 
         result_indicator_period = self.get_model('ResultIndicatorPeriod')
         result_indicator_period_target = models.ResultIndicatorPeriodTarget()
@@ -3439,14 +3437,12 @@ class Parse(IatiParser):
         try:
             value = Decimal(value)
         except Exception as e:
-            value = None
-
-        if value is None:
-            raise RequiredFieldError(
-                "result/indicator/period/actual",
-                "value",
-                "required attribute missing (this error might be incorrect, \
-                        xsd:decimal is used to check instead of xsd:string)")
+            value = 0  # value could be None according to
+            # iati-specification but we should not add None to our database
+            # otherwise it would raise error in endpoint aggregation.
+            # Example API call:
+            # /api/results/aggregations/?group_by=result_indicator_title
+            # &aggregations=actuals&format=json
 
         result_indicator_period = self.get_model('ResultIndicatorPeriod')
 

--- a/OIPA/iati/parser/IATI_2_03.py
+++ b/OIPA/iati/parser/IATI_2_03.py
@@ -4598,7 +4598,7 @@ class Parse(IatiParser):
 
         result_indicator_period_actual = models.ResultIndicatorPeriodActual()
         result_indicator_period_actual.result_indicator_period = result_indicator_period  # NOQA: E501
-        result_indicator_period_actual.value = value or ''  # can be None
+        result_indicator_period_actual.value = value
 
         self.register_model(
             'ResultIndicatorPeriodActual', result_indicator_period_actual)

--- a/OIPA/iati/parser/tests/test_2_03_parser.py
+++ b/OIPA/iati/parser/tests/test_2_03_parser.py
@@ -4690,7 +4690,7 @@ class ActivityResultIndicatorPeriodActualTestCase(TestCase):
 
         self.assertEqual(
             result_indicator_period_actual.value,
-            ''
+            0
         )
 
         # 2) test if value is provided:
@@ -4768,7 +4768,7 @@ class ActivityResultIndicatorPeriodActualTestCase(TestCase):
         self.assertEqual(self.result_indicator_period.actuals.count(), 4)
 
         self.assertListEqual(
-            ['', '11', '20', '21'],
+            ['0', '11', '20', '21'],
             list(self.result_indicator_period.actuals.values_list(
                 'value', flat=True
             ))


### PR DESCRIPTION
#1477 

-delete `or ' '` in `result_indicator_period_actual.value or ' ' ` statement from `iati_activities__iati_activity__result__indicator__period__actual` parsing method.

- change test accordingly.