### PR TITLE
OIPA-1646

### DIFF
--- a/OIPA/api/iati/references.py
+++ b/OIPA/api/iati/references.py
@@ -2212,7 +2212,7 @@ class CapitalSpendReference(ElementReference):
     # />
 
     def create(self):
-        if self.data:
+        if self.data is not None:
             # <capital-spend
             capital_spend_element = etree.SubElement(
                 self.parent_element, self.element


### PR DESCRIPTION
make `capital-spend` element to include in xml export even if the value(percentage) is 0. #1646